### PR TITLE
DCS-877 Bug fix: GET for email addresses is not protected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,21 @@ Self-contained fat-jar micro-service to publish prison information
 ### Running
 
 ```bash
-./gradlew bootRun
+./gradlew bootRun  --args='--spring.profiles.active=dev' 
 ```
+Which isn't very useful.
+Alternatively, to run with a local auth service and postgres first start those docker images using docker-compose
+Then run like this:
+```bash
+./gradlew bootRun --args='--spring.profiles.active=postgres,local' 
+```
+or
+```bash
+SPRING_PROFILES_ACTIVE=postgres,local ./gradlew bootRun
+```
+Swagger documentation is now at http://localhost:8080/swagger-ui.html
 
+You can obtain valid auth tokens form the local auth server using curl.
 #### Health
 
 - `/health/ping`: will respond with status `UP` to all requests.  This should be used by dependent systems to check connectivity to prison-register,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/PrisonService.kt
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.prisonregister.resource.PrisonDto
 import javax.persistence.EntityNotFoundException
 
-const val HAS_MAINTAIN_REF_DATA_ROLE = "hasRole('MAINTAIN_REF_DATA')"
+const val CLIENT_CAN_MAINTAIN_EMAIL_ADDRESSES = "hasRole('MAINTAIN_REF_DATA') and hasAuthority('SCOPE_write')"
 
 @Service
 class PrisonService(
@@ -36,7 +36,7 @@ class PrisonService(
     ?.run { emailAddress }
 
   @Transactional
-  @PreAuthorize(HAS_MAINTAIN_REF_DATA_ROLE)
+  @PreAuthorize(CLIENT_CAN_MAINTAIN_EMAIL_ADDRESSES)
   fun setVccEmailAddress(prisonId: String, emailAddress: String): SetOutcome {
     val vcc = videoLinkConferencingCentreRepository.findByIdOrNull(prisonId)
     return if (vcc == null) {
@@ -50,7 +50,7 @@ class PrisonService(
   }
 
   @Transactional
-  @PreAuthorize(HAS_MAINTAIN_REF_DATA_ROLE)
+  @PreAuthorize(CLIENT_CAN_MAINTAIN_EMAIL_ADDRESSES)
   fun setOmuEmailAddress(prisonId: String, emailAddress: String): SetOutcome {
     val omu = offenderManagementUnitRepository.findByIdOrNull(prisonId)
     return if (omu != null) {
@@ -64,7 +64,7 @@ class PrisonService(
   }
 
   @Transactional
-  @PreAuthorize(HAS_MAINTAIN_REF_DATA_ROLE)
+  @PreAuthorize(CLIENT_CAN_MAINTAIN_EMAIL_ADDRESSES)
   fun deleteOmuEmailAddress(prisonId: String) {
     if (offenderManagementUnitRepository.existsById(prisonId)) {
       offenderManagementUnitRepository.deleteById(prisonId)
@@ -72,7 +72,7 @@ class PrisonService(
   }
 
   @Transactional
-  @PreAuthorize(HAS_MAINTAIN_REF_DATA_ROLE)
+  @PreAuthorize(CLIENT_CAN_MAINTAIN_EMAIL_ADDRESSES)
   fun deleteVccEmailAddress(prisonId: String) {
     if (videoLinkConferencingCentreRepository.existsById(prisonId)) {
       videoLinkConferencingCentreRepository.deleteById(prisonId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonregister.model.Prison
 import uk.gov.justice.digital.hmpps.prisonregister.model.PrisonService
@@ -28,13 +27,14 @@ import javax.validation.constraints.Size
 const val OMU = "offender-management-unit"
 const val VCC = "videolink-conferencing-centre"
 const val EMAIL_ADDRESS = "email-address"
-const val PRISON_BY_ID = "/id/{prisonId}"
+const val PRISONS = "prisons"
+const val PRISON_BY_ID = "$PRISONS/id/{prisonId}"
+const val SECURE_PRISON_BY_ID = "secure/$PRISON_BY_ID"
 
 @RestController
 @Validated
-@RequestMapping("/prisons", produces = [MediaType.APPLICATION_JSON_VALUE])
 class PrisonResource(private val prisonService: PrisonService) {
-  @GetMapping(PRISON_BY_ID)
+  @GetMapping("/$PRISON_BY_ID", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Get specified prison", description = "Information on a specific prison")
   @ApiResponses(
     value = [
@@ -50,7 +50,7 @@ class PrisonResource(private val prisonService: PrisonService) {
     @PathVariable @Size(max = 12, min = 2) prisonId: String
   ): PrisonDto = prisonService.findById(prisonId)
 
-  @GetMapping("")
+  @GetMapping("/$PRISONS", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Get all prisons", description = "All prisons")
   @ApiResponses(
     value = [
@@ -64,7 +64,7 @@ class PrisonResource(private val prisonService: PrisonService) {
   fun getPrisons(): List<PrisonDto> = prisonService.findAll()
 
   @GetMapping(
-    "$PRISON_BY_ID/$VCC/$EMAIL_ADDRESS",
+    "/$SECURE_PRISON_BY_ID/$VCC/$EMAIL_ADDRESS",
     produces = [MediaType.TEXT_PLAIN_VALUE]
   )
   @Operation(summary = "Get a prison's Videolink Conferencing Centre email address")
@@ -97,7 +97,7 @@ class PrisonResource(private val prisonService: PrisonService) {
       ?: ResponseEntity.notFound().build()
 
   @GetMapping(
-    "$PRISON_BY_ID/$OMU/$EMAIL_ADDRESS",
+    "/$SECURE_PRISON_BY_ID/$OMU/$EMAIL_ADDRESS",
     produces = [MediaType.TEXT_PLAIN_VALUE]
   )
   @Operation(summary = "Get a prison's Offender Management Unit email address")
@@ -130,7 +130,7 @@ class PrisonResource(private val prisonService: PrisonService) {
       ?: ResponseEntity.notFound().build()
 
   @PutMapping(
-    "$PRISON_BY_ID/$VCC/$EMAIL_ADDRESS",
+    "/$SECURE_PRISON_BY_ID/$VCC/$EMAIL_ADDRESS",
     consumes = [MediaType.TEXT_PLAIN_VALUE]
   )
   @Operation(summary = "Set or change a prison's Videolink Conferencing Centre email address")
@@ -172,7 +172,7 @@ class PrisonResource(private val prisonService: PrisonService) {
     }.build()
 
   @PutMapping(
-    "/$PRISON_BY_ID/$OMU/$EMAIL_ADDRESS",
+    "/$SECURE_PRISON_BY_ID/$OMU/$EMAIL_ADDRESS",
     consumes = [MediaType.TEXT_PLAIN_VALUE]
   )
   @Operation(summary = "Set or change a prison's Offender Management Unit email address")
@@ -213,7 +213,7 @@ class PrisonResource(private val prisonService: PrisonService) {
       SetOutcome.UPDATED -> ResponseEntity.noContent()
     }.build()
 
-  @DeleteMapping("$PRISON_BY_ID/$VCC/$EMAIL_ADDRESS")
+  @DeleteMapping("/$SECURE_PRISON_BY_ID/$VCC/$EMAIL_ADDRESS")
   @Operation(summary = "Remove a prison's Videolink Conferencing Centre email address")
   @ApiResponses(
     value = [
@@ -237,7 +237,7 @@ class PrisonResource(private val prisonService: PrisonService) {
     return ResponseEntity.noContent().build()
   }
 
-  @DeleteMapping("$PRISON_BY_ID/$OMU/$EMAIL_ADDRESS")
+  @DeleteMapping("/$SECURE_PRISON_BY_ID/$OMU/$EMAIL_ADDRESS")
   @Operation(summary = "Remove a prison's Offender Management Unit email address")
   @ApiResponses(
     value = [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/PrisonServiceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/PrisonServiceSecurityTest.kt
@@ -12,7 +12,8 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import java.util.Optional
 
-const val ROLE_MAINTAIN_REF_DATA = "MAINTAIN_REF_DATA"
+@WithMockUser(authorities = ["ROLE_MAINTAIN_REF_DATA", "SCOPE_write"])
+annotation class WithMaintenanceMockUser
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
@@ -28,7 +29,7 @@ class PrisonServiceSecurityTest(@Autowired val prisonService: PrisonService) {
   lateinit var videoLinkConferencingCentreRepository: VideoLinkConferencingCentreRepository
 
   @Test
-  @WithMockUser(roles = [ROLE_MAINTAIN_REF_DATA])
+  @WithMaintenanceMockUser
   fun `Authorised user can update OMU email`() {
     whenever(offenderManagementUnitRepository.findById(ArgumentMatchers.anyString())).thenReturn(
       Optional.of(
@@ -51,7 +52,7 @@ class PrisonServiceSecurityTest(@Autowired val prisonService: PrisonService) {
   }
 
   @Test
-  @WithMockUser(roles = [ROLE_MAINTAIN_REF_DATA])
+  @WithMaintenanceMockUser
   fun `Authorised user can delete OMU email`() {
     prisonService.deleteOmuEmailAddress("MDI")
   }
@@ -64,7 +65,7 @@ class PrisonServiceSecurityTest(@Autowired val prisonService: PrisonService) {
   }
 
   @Test
-  @WithMockUser(roles = [ROLE_MAINTAIN_REF_DATA])
+  @WithMaintenanceMockUser
   fun `Authorised user can update VCC email`() {
     whenever(videoLinkConferencingCentreRepository.findById(ArgumentMatchers.anyString())).thenReturn(
       Optional.of(
@@ -87,7 +88,7 @@ class PrisonServiceSecurityTest(@Autowired val prisonService: PrisonService) {
   }
 
   @Test
-  @WithMockUser(roles = [ROLE_MAINTAIN_REF_DATA])
+  @WithMaintenanceMockUser
   fun `Authorised user can delete VCC email`() {
     prisonService.deleteVccEmailAddress("MDI")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/utilities/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/utilities/JwtAuthHelper.kt
@@ -32,7 +32,7 @@ class JwtAuthHelper {
     scope: List<String>? = listOf(),
     roles: List<String>? = listOf(),
     expiryTime: Duration = Duration.ofHours(1),
-    clientId: String = "whereabouts-api",
+    clientId: String = "prison-register-client",
     jwtId: String = UUID.randomUUID().toString(),
   ): String {
     val claims = mutableMapOf<String, Any?>("user_name" to subject, "client_id" to clientId, "user_id" to userId)


### PR DESCRIPTION
Move OMU and VCC email resource URIs under resource root `/secure`. 
E.g:
```
/secure/prisons/id/{prisonId}/offender-management-unit/email-address
/secure/prisons/id/{prisonId}/video-link-conferencing-centre/email-address
```
All operations under resource root `/secure` require a valid OAuth token.
Additionally, PUT and DELETE operations on these resources require a valid OAuth token containing authorities "ROLE_MAINTAIN_REF_DATA" and "SCOPE_write".