### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/prison-register/Chart.yaml
+++ b/helm_deploy/prison-register/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 
 dependencies:
   - name: generic-service
-    version: 2.6.3
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.2


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


