### PR TITLE
Fix docker-compose files

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   prison-register:
     build:
@@ -22,7 +21,7 @@ services:
       - AWS_DEFAULT_REGION=eu-west-2
 
   prison-register-db:
-    image: postgres:15
+    image: postgres:16
     networks:
       - hmpps
     container_name: prison-register-db
@@ -48,13 +47,13 @@ services:
       DELIUS_ENABLED: "false"
 
   localstack:
-    image: localstack/localstack:1.4
+    image: localstack/localstack:3
     networks:
       - hmpps
     container_name: localstack
     ports:
       - "4566-4597:4566-4597"
-      - 8999:8080
+      - "8999:8080"
     environment:
       - SERVICES=sns,sqs
       - DEBUG=${DEBUG- }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   prison-register:
     build:
@@ -48,13 +47,13 @@ services:
       DELIUS_ENABLED: "false"
 
   localstack:
-    image: localstack/localstack:1.4
+    image: localstack/localstack:3
     networks:
       - hmpps
     container_name: localstack
     ports:
       - "4566-4597:4566-4597"
-      - 8999:8080
+      - "8999:8080"
     environment:
       - SERVICES=sns,sqs
       - DEBUG=${DEBUG- }


### PR DESCRIPTION
It is not possible to run the integration tests unless the docker-compose files are fixed. They need **localstack:3** for the code to run successfully.

Includes minor fixes to the files. Both files are currently identical, should **-test.yml** be the same but without `prison-register` running as a service?