### PR TITLE
MAP-1458 PrisonService findByPrisonFilter without textSearch without Active


### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/service/PrisonServiceTest.kt
@@ -123,6 +123,15 @@ class PrisonServiceTest {
 
       assertThat(results).containsOnly(PrisonDto(prison))
     }
+
+    @Test
+    fun `find prison by non active and non text search`() {
+      val prison = Prison("MNI", "Thameside (HMP)", active = false)
+      whenever(prisonRepository.findAll(any<PrisonFilter>())).thenReturn(listOf(prison))
+      val results = prisonService.findByPrisonFilter()
+
+      assertThat(results).containsOnly(PrisonDto(prison))
+    }
   }
 
   @Nested


### PR DESCRIPTION
As I am working reducing gaps found in the Kover report.
Class overall coverage is increased by 85.7% to 86.1% with this commit

Before
![image](https://github.com/user-attachments/assets/26abfc34-f6f0-4e80-8619-9fd64f68a97f)

After
![image](https://github.com/user-attachments/assets/fc4b7f6f-7f79-44a8-a985-cffb6293762f)
