### PR TITLE
Renovate generic prometheus alerts 1.x and generic services

### DIFF
--- a/helm_deploy/prison-register/Chart.yaml
+++ b/helm_deploy/prison-register/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: "3.4"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.8"
+    version: "1.9"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/prison-register/Chart.yaml
+++ b/helm_deploy/prison-register/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 
 dependencies:
   - name: generic-service
-    version: "3.4"
+    version: "3.5"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: "1.9"


### PR DESCRIPTION
Now in line with [the Kotlin template]( https://github.com/ministryofjustice/hmpps-template-kotlin/blob/fcedcc78934cecc5df53496f4d1a6d54557972b5/helm_deploy/hmpps-template-kotlin/Chart.yaml)