### PR TITLE
Map 1673 add endpoint to return only name given prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
@@ -128,7 +128,7 @@ class PrisonResource(private val prisonService: PrisonService, private val addre
     "/names",
     produces = [MediaType.APPLICATION_JSON_VALUE],
   )
-  @Operation(summary = "Get prison names", description = "prison id and full name")
+  @Operation(summary = "Get prison name(s)", description = "prison id and full name")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -139,8 +139,9 @@ class PrisonResource(private val prisonService: PrisonService, private val addre
   )
   fun getPrisonNames(
     @Parameter(description = "If active is not set, return all prisons, otherwise return only the active or inactive ones based on the value", example = "true", required = false) @RequestParam active: Boolean?,
+    @Parameter(description = "If parameter prisonId is not set, return the names all prisons, otherwise return only the one corresponding to the prisonId code.  filtering on active still applies", example = "WDI", required = false) @RequestParam prison_id: String?,
   ): List<PrisonNameDto> {
-    return prisonService.getPrisonNames(active)
+    return prisonService.getPrisonNames(active, prison_id)
   }
 
   @PostMapping("/prisonsByIds", consumes = ["application/json"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
@@ -139,7 +139,7 @@ class PrisonResource(private val prisonService: PrisonService, private val addre
   )
   fun getPrisonNames(
     @Parameter(description = "If active is not set, return all prisons, otherwise return only the active or inactive ones based on the value", example = "true", required = false) @RequestParam active: Boolean?,
-    @Parameter(description = "If parameter prisonId is not set, return the names all prisons, otherwise return only the one corresponding to the prisonId code.  filtering on active still applies", example = "WDI", required = false) @RequestParam prison_id: String?,
+    @Parameter(description = "If parameter prisonId is not set, return the names of all prisons, otherwise return only the one corresponding to the prisonId code.  Filtering on active still applies", example = "WDI", required = false) @RequestParam prison_id: String?,
   ): List<PrisonNameDto> {
     return prisonService.getPrisonNames(active, prison_id)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/service/PrisonService.kt
@@ -341,8 +341,10 @@ class PrisonService(
   }
 
   @Transactional(readOnly = true)
-  fun getPrisonNames(active: Boolean?): List<PrisonNameDto> {
-    return prisonRepository.findByActiveOrderByPrisonId(active = active).map { PrisonNameDto(it.prisonId, it.name) }
+  fun getPrisonNames(active: Boolean?, prisonId: String?): List<PrisonNameDto> {
+    return prisonRepository.findByActiveOrderByPrisonId(active = active)
+      .filter { prisonId == null || it.prisonId == prisonId }
+      .map { PrisonNameDto(it.prisonId, it.name) }
   }
 
   private fun removeOrphanedContactDetails(contactDetails: ContactDetailsDto) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/integration/GetPrisonNames.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/integration/GetPrisonNames.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.prisonregister.integration
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisonregister.resource.dto.PrisonNameDto
 
@@ -75,6 +77,63 @@ class GetPrisonNames : IntegrationTest() {
     with(prisonNames.last()) {
       Assertions.assertThat(prisonId).isEqualTo("WOI")
       Assertions.assertThat(prisonName).isEqualTo("Wolds (HMP)")
+    }
+  }
+
+  /**
+   * Different combinations of 'active' and 'name' for positive (is not empty result) and negative (is empty result) scenarios,
+   * CVS(active,prisonId,isNotEmpty)
+   *
+   * WDI : active prisonID with name "Wakefield (HMP)"
+   * WOI : non active prisonID with name "Wolds (HMP)"
+   */
+  @ParameterizedTest
+  @CsvSource(
+    "true,WDI,true",
+    "null,WDI,true",
+    "false,WOI,true",
+    "null,WOI,true",
+    "false,WDI,false",
+    "true,WOI,false",
+    "false,XXX,false",
+    "true,XXX,false",
+    "null,XXX,false",
+  )
+  fun `should return prison names based on any kind of active value, name, positive scenarios`(active: String?, prison_id: String?, isNotEmpty: Boolean) {
+    val queryParams = mutableListOf<String>()
+    if (active != "null") {
+      queryParams.add("active=$active")
+    }
+    if (prison_id != "null") {
+      queryParams.add("prison_id=$prison_id")
+    }
+
+    val endPoint = "/prisons/names?" + queryParams.joinToString("&")
+
+    // When
+    val responseSpec = webTestClient.get().uri(endPoint)
+      .exchange()
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    val prisonNames = getPrisonNames(responseSpec.expectBody())
+
+    when (isNotEmpty) {
+      true -> {
+        Assertions.assertThat(prisonNames).isNotEmpty
+        when (prison_id) {
+          "WDI" -> with(prisonNames.last()) {
+            Assertions.assertThat(prisonId).isEqualTo("WDI")
+            Assertions.assertThat(prisonName).isEqualTo("Wakefield (HMP)")
+          }
+          "WOI" -> with(prisonNames.last()) {
+            Assertions.assertThat(prisonId).isEqualTo("WOI")
+            Assertions.assertThat(prisonName).isEqualTo("Wolds (HMP)")
+          }
+        }
+      }
+      false -> Assertions.assertThat(prisonNames).isEmpty()
     }
   }
 


### PR DESCRIPTION
It reuses /prisons/names endpoint and resource and active and non active parameter

This gives us more capabilities in a single endpoint.
Parametes active & prison_id (they are not required)
As an example /prisons/names/active=true&prison_id=WDI should return "Wakefield (HMP)".
As an example /prisons/names/active=false&prison_id=WDI should return an empty list.
As an example /prisons/names/active=true&prison_id=XXX should return an empty list as XXX doesn't exist.

and previous behaviour

As an example /prisons/names/ should return an list of prison
As an example /prisons/names/active=true should return an list of active prison