### PR TITLE
MAPB-444: allow null prisonIds and fix swagger in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,8 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     AUDIT_ENDPOINT_URL: "https://audit-api-dev.hmpps.service.justice.gov.uk"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    SPRINGDOC_API_DOCS_ENABLED: "true"
+    SPRINGDOC_SWAGGER_UI_ENABLED: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 generic-prometheus-alerts:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
@@ -159,7 +159,7 @@ class PrisonResource(private val prisonService: PrisonService, private val addre
   )
   fun getPrisonsByIds(
     @RequestBody @Valid prisonRequest: PrisonRequest,
-  ) = prisonService.findPrisonsByIds(prisonRequest.prisonIds ?: emptyList())
+  ) = prisonService.findPrisonsByIds(prisonRequest.prisonIds?.filterNotNull() ?: emptyList())
 }
 
 @Schema(description = "Prison Information")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResource.kt
@@ -159,7 +159,7 @@ class PrisonResource(private val prisonService: PrisonService, private val addre
   )
   fun getPrisonsByIds(
     @RequestBody @Valid prisonRequest: PrisonRequest,
-  ) = prisonService.findPrisonsByIds(prisonRequest.prisonIds)
+  ) = prisonService.findPrisonsByIds(prisonRequest.prisonIds ?: emptyList())
 }
 
 @Schema(description = "Prison Information")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/model/PrisonRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/model/PrisonRequest.kt
@@ -1,13 +1,11 @@
 package uk.gov.justice.digital.hmpps.prisonregister.resource.model
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
 
 data class PrisonRequest(
   @Schema(description = "List of prison ids", required = true)
-  @field:NotEmpty(message = "Prison ids must not be empty")
   val prisonIds: List<
     @Size(min = 3, max = 6, message = "Prison Id must be between 3 and 6 letters")
     String,
-    >,
+    >? = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/model/PrisonRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/model/PrisonRequest.kt
@@ -6,6 +6,6 @@ data class PrisonRequest(
   @Schema(description = "List of prison ids", required = true)
   val prisonIds: List<
     @Size(min = 3, max = 6, message = "Prison Id must be between 3 and 6 letters")
-    String,
+    String?,
     >? = emptyList(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResourceIntTest.kt
@@ -158,6 +158,18 @@ class PrisonResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `find prisons by ids allows null list`() {
+      whenever(prisonRepository.findAllByPrisonIdIsIn(emptyList())).thenReturn(emptyList())
+
+      webTestClient.post().uri("/prisons/prisonsByIds")
+        .header("Content-Type", "application/json")
+        .bodyValue(PrisonRequest(null))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json("[]")
+    }
+
+    @Test
     fun `find prison validation failure`() {
       webTestClient.get().uri("/prisons/id/1234567890123")
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/PrisonResourceIntTest.kt
@@ -170,6 +170,18 @@ class PrisonResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `find prisons by ids ignores null values in list`() {
+      whenever(prisonRepository.findAllByPrisonIdIsIn(emptyList())).thenReturn(emptyList())
+
+      webTestClient.post().uri("/prisons/prisonsByIds")
+        .header("Content-Type", "application/json")
+        .bodyValue(PrisonRequest(listOf(null)))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json("[]")
+    }
+
+    @Test
     fun `find prison validation failure`() {
       webTestClient.get().uri("/prisons/id/1234567890123")
         .exchange()


### PR DESCRIPTION
1. Fixes POST /prisons/prisonsByIds to tolerate payloads where prisonIds contains null values
2. Add dev env vars to enable swagger

Tested the following

1. POST http://localhost:8080/prisons/prisonsByIds
{
  "prisonIds": [null]
}

2. POST http://localhost:8080/prisons/prisonsByIds
{
  "prisonIds": [""]
}

3. POST http://localhost:8080/prisons/prisonsByIds
{
  "prisonIds": null
}

