### PR TITLE
SDIT-4014 Add court data model.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/AgencyAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/AgencyAddress.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import jakarta.persistence.Entity
+
+@Entity
+class AgencyAddress(
+  var addressLine1: String? = null,
+  var addressLine2: String? = null,
+  var town: String? = null,
+  var county: String? = null,
+  var postcode: String? = null,
+  var country: String? = null,
+) : AbstractIdEntity()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/AgencyAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/AgencyAddressRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AgencyAddressRepository : JpaRepository<AgencyAddress, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/Area.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/Area.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "area")
+class Area(
+  @Id
+  @Column(unique = true)
+  var code: String,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent")
+  var region: Region?,
+  var description: String,
+  @Suppress("unused") var prisonArea: Boolean = false,
+  var active: Boolean = false,
+
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/AreaRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/AreaRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AreaRepository : JpaRepository<Area, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/Court.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/Court.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import org.hibernate.Hibernate
+import java.time.LocalDate
+
+@Entity
+data class Court(
+  @Id
+  @Column(unique = true)
+  val courtId: String,
+  var name: String,
+  var description: String?,
+  var active: Boolean,
+  var inactiveDate: LocalDate?,
+  var cjitCode: String?,
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "area")
+  var area: Area?,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region")
+  var region: Region?,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "court_type")
+  var courtType: CourtType,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
+  @JoinTable(
+    name = "court_to_agency_address",
+    joinColumns = [JoinColumn(name = "court_id")],
+    inverseJoinColumns = [JoinColumn(name = "agency_address_id", referencedColumnName = "id")],
+  )
+  var addresses: MutableList<AgencyAddress> = mutableListOf(),
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
+  @JoinTable(
+    name = "court_to_email_address",
+    joinColumns = [JoinColumn(name = "court_id")],
+    inverseJoinColumns = [JoinColumn(name = "email_address_id", referencedColumnName = "id")],
+  )
+  var emailAddresses: MutableList<EmailAddress> = mutableListOf(),
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
+  @JoinTable(
+    name = "court_to_phone",
+    joinColumns = [JoinColumn(name = "court_id")],
+    inverseJoinColumns = [JoinColumn(name = "phone_id", referencedColumnName = "id")],
+  )
+  var phoneNumbers: MutableList<PhoneNumber> = mutableListOf(),
+
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as Court
+
+    return courtId == other.courtId
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  @Override
+  override fun toString(): String = this::class.simpleName + "(courtId = $courtId, name = $name, description = $description"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/CourtRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/CourtRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CourtRepository : JpaRepository<Court, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/CourtType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/CourtType.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "court_type")
+class CourtType(
+  @Id
+  @Column(unique = true)
+  var code: String,
+  var description: String,
+  var active: Boolean = false,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/CourtTypeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/CourtTypeRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CourtTypeRepository : JpaRepository<CourtType, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/Region.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/Region.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "region")
+class Region(
+  @Id
+  @Column(unique = true)
+  var code: String,
+  var description: String,
+  var active: Boolean = false,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/RegionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/model/RegionRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prisonregister.model
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RegionRepository : JpaRepository<Region, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/CourtResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/CourtResource.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.prisonregister.resource
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.constraints.Size
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prisonregister.service.CourtService
+import java.time.LocalDate
+
+@RestController
+@Validated
+@RequestMapping("/courts", produces = [MediaType.APPLICATION_JSON_VALUE])
+@PreAuthorize("hasAnyRole('ROLE_HMPPS_REGISTERS_API__SYNCHRONISATION__RW')")
+class CourtResource(private val courtService: CourtService) {
+  @GetMapping("/id/{courtId}")
+  @Operation(summary = "Get specified court", description = "Information on a specific court")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful Operation",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = PrisonDto::class))],
+      ),
+    ],
+  )
+  fun getCourtFromId(
+    @Schema(description = "Court ID", example = "SHEFCC", required = true)
+    @PathVariable
+    @Size(min = 3, max = 6, message = "Court Id must be between 3 and 6 letters")
+    courtId: String,
+  ): CourtDto = courtService.findById(courtId)
+}
+
+@Schema(description = "Court Information")
+@JsonInclude(NON_NULL)
+data class CourtDto(
+  @Schema(description = "Court ID", example = "NWCLYC") val courtId: String,
+  @Schema(description = "Name", example = "N Staffs Youth Court - Newcastle") val courtName: String,
+  @Schema(description = "Description", example = "North Staffordshire Youth Court - Newcastle under Lyme") val description: String?,
+  @Schema(description = "Whether still active") val active: Boolean,
+  val inactiveDate: LocalDate?,
+  @Schema(description = "CJIT Code", example = "123456789") val cjitCode: String?,
+  @Schema(description = "Area") val area: CodeDescription?,
+  @Schema(description = "Region") val region: CodeDescription?,
+  @Schema(description = "courtType") val courtType: CodeDescription?,
+  @Schema(description = "addresses") val addresses: List<AgencyAddressDto>,
+  @Schema(description = "emailAddresses") val emailAddresses: List<AgencyEmailDto>,
+  @Schema(description = "phoneNumbers") val phoneNumbers: List<AgencyPhoneDto>,
+)
+
+@JsonInclude(NON_NULL)
+data class AgencyAddressDto(
+  @Schema(description = "Unique ID of the address", example = "10000") val id: Long,
+  @Schema(description = "Address line 1", example = "Bawtry Road") val addressLine1: String?,
+  @Schema(description = "Address line 2", example = "Hatfield Woodhouse") val addressLine2: String?,
+  @Schema(description = "Village/Town/City", example = "Doncaster") val town: String?,
+  @Schema(description = "County", example = "South Yorkshire") val county: String?,
+  @Schema(description = "Postcode", example = "DN7 6BW") val postcode: String?,
+  @Schema(description = "Country", example = "England") val country: String?,
+)
+
+@JsonInclude(NON_NULL)
+data class AgencyPhoneDto(
+  @Schema(description = "Unique ID of the phone number", example = "10000") val id: Long,
+  @Schema(description = "Phone number", example = "0114 555 9898") val number: String?,
+)
+
+@JsonInclude(NON_NULL)
+data class AgencyEmailDto(
+  @Schema(description = "Unique ID of the email address", example = "10000") val id: Long,
+  @Schema(description = "Email address", example = "example@example.com") val address: String?,
+)
+
+data class CodeDescription(val code: String, val description: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/service/CourtService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonregister/service/CourtService.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.prisonregister.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.prisonregister.model.CourtRepository
+import uk.gov.justice.digital.hmpps.prisonregister.resource.AgencyAddressDto
+import uk.gov.justice.digital.hmpps.prisonregister.resource.AgencyEmailDto
+import uk.gov.justice.digital.hmpps.prisonregister.resource.AgencyPhoneDto
+import uk.gov.justice.digital.hmpps.prisonregister.resource.CodeDescription
+import uk.gov.justice.digital.hmpps.prisonregister.resource.CourtDto
+
+@Service
+@Transactional
+class CourtService(
+  private val courtRepository: CourtRepository,
+) {
+  fun findById(courtId: String): CourtDto = courtRepository.findByIdOrNull(courtId)?.let {
+    CourtDto(
+      courtId = it.courtId,
+      courtName = it.name,
+      description = it.description,
+      active = it.active,
+      inactiveDate = it.inactiveDate,
+      cjitCode = it.cjitCode,
+      area = it.area?.let { area -> CodeDescription(area.code, area.description) },
+      region = it.region?.let { area -> CodeDescription(area.code, area.description) },
+      courtType = CodeDescription(it.courtType.code, it.courtType.description),
+      addresses = it.addresses.map { address ->
+        AgencyAddressDto(
+          id = address.id,
+          addressLine1 = address.addressLine1,
+          addressLine2 = address.addressLine2,
+          town = address.town,
+          county = address.county,
+          postcode = address.postcode,
+          country = address.country,
+        )
+      },
+      emailAddresses = it.emailAddresses.map { emailAddress ->
+        AgencyEmailDto(
+          id = emailAddress.id,
+          address = emailAddress.value,
+        )
+      },
+      phoneNumbers = it.phoneNumbers.map { phoneNumber ->
+        AgencyPhoneDto(
+          id = phoneNumber.id,
+          number = phoneNumber.value,
+        )
+      },
+    )
+  } ?: throw EntityNotFoundException("Court $courtId not found")
+}

--- a/src/main/resources/db/migration/V1_44__court_tables.sql
+++ b/src/main/resources/db/migration/V1_44__court_tables.sql
@@ -1,0 +1,52 @@
+create table court
+(
+    court_id      varchar(6)  not null primary key,
+    name          varchar(40) not null,
+    description   varchar(3000),
+    active        boolean     not null,
+    inactive_date date,
+    court_type    varchar(12) not null,
+    area          varchar(12),
+    region        varchar(12),
+    cjit_code     varchar(12),
+    constraint court_area_fk foreign key (area) references area (code),
+    constraint court_region_fk foreign key (region) references region (code)
+);
+
+create table agency_address
+(
+    id              serial primary key,
+    address_line1 varchar(350),
+    address_line2 varchar(80),
+    town          varchar(80),
+    county        varchar(80),
+    postcode      varchar(8),
+    country       varchar(16)
+);
+
+create table court_to_agency_address
+(
+    court_id          varchar(6) not null,
+    agency_address_id integer    not null,
+    constraint court_to_agency_address_to_court_fk foreign key (court_id) references court (court_id),
+    constraint court_to_agency_address_to_agency_address_fk foreign key (agency_address_id) references agency_address (id)
+);
+
+create index court_to_agency_address_idx on court_to_agency_address (court_id, agency_address_id);
+
+
+create table court_to_phone
+(
+    court_id          varchar(6) not null,
+    phone_id integer    not null,
+    constraint court_to_phone_to_court_fk foreign key (court_id) references court (court_id),
+    constraint court_to_phone_to_phone_fk foreign key (phone_id) references phone_number (id)
+);
+
+create table court_to_email_address
+(
+    court_id          varchar(6) not null,
+    email_address_id integer    not null,
+    constraint court_to_email_address_to_court_fk foreign key (court_id) references court (court_id),
+    constraint court_to_email_address_to_email_address_fk foreign key (email_address_id) references email_address (id)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/AgencyAddress.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/AgencyAddress.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.prisonregister.dsl
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonregister.model.AgencyAddress
+import uk.gov.justice.digital.hmpps.prisonregister.model.AgencyAddressRepository
+
+@DslMarker
+annotation class AgencyAddressDslMarker
+
+@AgencyAddressDslMarker
+@Component
+class AgencyAddress(val agencyAddressRepository: AgencyAddressRepository) {
+  fun build(
+    addressLine1: String?,
+    addressLine2: String?,
+    town: String?,
+    county: String?,
+    postcode: String?,
+    country: String?,
+  ): AgencyAddress = agencyAddressRepository.saveAndFlush(
+    AgencyAddress(
+      addressLine1 = addressLine1,
+      addressLine2 = addressLine2,
+      town = town,
+      county = county,
+      postcode = postcode,
+      country = country,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/Court.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/Court.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.prisonregister.dsl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonregister.model.AreaRepository
+import uk.gov.justice.digital.hmpps.prisonregister.model.Court
+import uk.gov.justice.digital.hmpps.prisonregister.model.CourtRepository
+import uk.gov.justice.digital.hmpps.prisonregister.model.CourtTypeRepository
+import uk.gov.justice.digital.hmpps.prisonregister.model.RegionRepository
+import java.time.LocalDate
+
+@DslMarker
+annotation class CourtDslMarker
+
+@CourtDslMarker
+@Component
+class Court(
+  private val courtTypeRepository: CourtTypeRepository,
+  private val areaRepository: AreaRepository,
+  private val regionRepository: RegionRepository,
+  private val courtRepository: CourtRepository,
+  private val addressBuilder: AgencyAddress,
+  private val phoneBuilder: PhoneNumber,
+  private val emailBuilder: EmailAddress,
+) {
+  lateinit var court: Court
+  fun build(
+    courtId: String,
+    name: String,
+    description: String,
+    active: Boolean,
+    inactiveDate: LocalDate?,
+    courtTypeCode: String,
+    cjitCode: String?,
+    areaCode: String?,
+    regionCode: String?,
+  ): Court = Court(
+    courtId = courtId,
+    name = name,
+    description = description,
+    active = active,
+    inactiveDate = inactiveDate,
+    courtType = courtTypeRepository.findByIdOrNull(courtTypeCode) ?: throw RuntimeException("Court type $courtTypeCode not found"),
+    cjitCode = cjitCode,
+    area = areaCode?.let { areaRepository.findByIdOrNull(areaCode) },
+    region = regionCode?.let { regionRepository.findByIdOrNull(regionCode) },
+  ).let {
+    courtRepository.saveAndFlush(it)
+  }.also {
+    court = it
+  }
+
+  fun address(
+    addressLine1: String? = null,
+    addressLine2: String? = null,
+    town: String? = null,
+    county: String? = null,
+    postcode: String? = null,
+    country: String? = null,
+  ): uk.gov.justice.digital.hmpps.prisonregister.model.AgencyAddress = addressBuilder.build(
+    addressLine1 = addressLine1,
+    addressLine2 = addressLine2,
+    town = town,
+    county = county,
+    postcode = postcode,
+    country = country,
+  ).also {
+    court.addresses.add(it)
+    courtRepository.save(court)
+  }
+  fun email(
+    emailAddress: String = "test@justice.gov.uk",
+  ): uk.gov.justice.digital.hmpps.prisonregister.model.EmailAddress = emailBuilder.build(
+    emailAddress = emailAddress,
+  ).also {
+    court.emailAddresses.add(it)
+    courtRepository.save(court)
+  }
+  fun phoneNumber(
+    phoneNumber: String = "0114 555 8989",
+  ): uk.gov.justice.digital.hmpps.prisonregister.model.PhoneNumber = phoneBuilder.build(
+    phoneNumber = phoneNumber,
+  ).also {
+    court.phoneNumbers.add(it)
+    courtRepository.save(court)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/EmailAddress.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/EmailAddress.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.prisonregister.dsl
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonregister.model.EmailAddressRepository
+
+@DslMarker
+annotation class EmailAddressDslMarker
+
+@EmailAddressDslMarker
+@Component
+class EmailAddress(val emailAddressRepository: EmailAddressRepository) {
+  fun build(
+    emailAddress: String,
+  ): uk.gov.justice.digital.hmpps.prisonregister.model.EmailAddress = emailAddressRepository.saveAndFlush(
+    uk.gov.justice.digital.hmpps.prisonregister.model.EmailAddress(
+      value = emailAddress,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/PhoneNumber.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/PhoneNumber.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.prisonregister.dsl
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonregister.model.PhoneNumber
+import uk.gov.justice.digital.hmpps.prisonregister.model.PhoneNumberRepository
+
+@DslMarker
+annotation class PhoneNumberDslMarker
+
+@PhoneNumberDslMarker
+@Component
+class PhoneNumber(val phoneNumberRepository: PhoneNumberRepository) {
+  fun build(
+    phoneNumber: String,
+  ): PhoneNumber = phoneNumberRepository.saveAndFlush(
+    PhoneNumber(
+      value = phoneNumber,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/Root.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/dsl/Root.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.prisonregister.dsl
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@DslMarker
+annotation class DataDslMarker
+
+@DataDslMarker
+@Component
+@Transactional
+class Root(val court: Court) {
+  fun court(
+    courtId: String,
+    name: String,
+    description: String = name,
+    active: Boolean = true,
+    inactiveDate: LocalDate? = null,
+    courtTypeCode: String = "CC",
+    cjitCode: String? = null,
+    areaCode: String? = null,
+    regionCode: String? = null,
+    dsl: Court.() -> Unit,
+  ): uk.gov.justice.digital.hmpps.prisonregister.model.Court = court.build(
+    courtId = courtId,
+    name = name,
+    description = description,
+    active = active,
+    inactiveDate = inactiveDate,
+    courtTypeCode = courtTypeCode,
+    cjitCode = cjitCode,
+    areaCode = areaCode,
+    regionCode = regionCode,
+  ).also {
+    dsl.invoke(court)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/integration/IntegrationTestBase.kt
@@ -92,3 +92,4 @@ abstract class IntegrationTestBase : TestBase() {
 
   fun testQueueEventMessageCount(): Int? = testSqsClient.countMessagesOnQueue(testQueueUrl).get()
 }
+inline fun <reified B : Any> WebTestClient.ResponseSpec.expectBodyResponse(): B = this.expectStatus().is2xxSuccessful.expectBody(B::class.java).returnResult().responseBody!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/CourtResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonregister/resource/CourtResourceIntTest.kt
@@ -1,0 +1,188 @@
+package uk.gov.justice.digital.hmpps.prisonregister.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.prisonregister.dsl.Root
+import uk.gov.justice.digital.hmpps.prisonregister.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonregister.integration.expectBodyResponse
+import uk.gov.justice.digital.hmpps.prisonregister.model.Court
+import uk.gov.justice.digital.hmpps.prisonregister.model.CourtRepository
+import java.time.LocalDate
+
+class CourtResourceIntTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var dsl: Root
+
+  @Autowired
+  lateinit var courtRepository: CourtRepository
+
+  @DisplayName("Get court by id")
+  @Nested
+  inner class GetById {
+    lateinit var court: Court
+
+    @BeforeEach
+    fun setUp() {
+      dsl.court(
+        courtId = "SHEFCC",
+        name = "Sheffield Central Ct",
+        description = "Sheffield Central Court",
+        active = false,
+        inactiveDate = LocalDate.parse("2020-01-02"),
+        courtTypeCode = "CC",
+        cjitCode = "C00SH00",
+        areaCode = "52",
+        regionCode = "YOHUM",
+      ) {
+        address(
+          addressLine1 = "Court House, 31 High Street",
+          addressLine2 = "City Centre",
+          town = "Sheffield",
+          county = "South Yorkshire",
+          postcode = "S1 3GG",
+          country = "England",
+        )
+        address(
+          postcode = "S10 2HH",
+        )
+        email(
+          emailAddress = "test@justice.gov.uk",
+        )
+        email(
+          emailAddress = "another@justice.gov.uk",
+        )
+        phoneNumber(
+          phoneNumber = "0114 555 8989",
+        )
+        phoneNumber(
+          phoneNumber = "0114 555 5555",
+        )
+      }
+    }
+
+    @AfterEach
+    fun tearDown() {
+      if (::court.isInitialized) {
+        courtRepository.delete(court)
+      }
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `requires a valid authentication token`() {
+        webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `requires correct role`() {
+        webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `allowed with correct role`() {
+        webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("HMPPS_REGISTERS_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isOk
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `404 if not found`() {
+        webTestClient.get()
+          .uri("/courts/id/ZZZZ")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("HMPPS_REGISTERS_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `will return core details `() {
+        val courtDto: CourtDto = webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("HMPPS_REGISTERS_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectBodyResponse()
+
+        assertThat(courtDto.courtId).isEqualTo("SHEFCC")
+        assertThat(courtDto.courtName).isEqualTo("Sheffield Central Ct")
+        assertThat(courtDto.description).isEqualTo("Sheffield Central Court")
+        assertThat(courtDto.active).isFalse
+        assertThat(courtDto.inactiveDate).isEqualTo("2020-01-02")
+        assertThat(courtDto.courtType?.description).isEqualTo("Crown Court")
+        assertThat(courtDto.area?.description).isEqualTo("South Yorkshire")
+        assertThat(courtDto.region?.description).isEqualTo("Yorkshire & Humberside")
+      }
+
+      @Test
+      fun `will return addresses `() {
+        val courtDto: CourtDto = webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("HMPPS_REGISTERS_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectBodyResponse()
+
+        assertThat(courtDto.addresses).hasSize(2)
+        assertThat(courtDto.addresses[0].addressLine1).isEqualTo("Court House, 31 High Street")
+        assertThat(courtDto.addresses[0].addressLine2).isEqualTo("City Centre")
+        assertThat(courtDto.addresses[0].town).isEqualTo("Sheffield")
+        assertThat(courtDto.addresses[0].county).isEqualTo("South Yorkshire")
+        assertThat(courtDto.addresses[0].postcode).isEqualTo("S1 3GG")
+        assertThat(courtDto.addresses[0].country).isEqualTo("England")
+      }
+
+      @Test
+      fun `will return emails `() {
+        val courtDto: CourtDto = webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("HMPPS_REGISTERS_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectBodyResponse()
+
+        assertThat(courtDto.emailAddresses).hasSize(2)
+        assertThat(courtDto.emailAddresses[0].address).isEqualTo("test@justice.gov.uk")
+      }
+
+      @Test
+      fun `will return phone numbers `() {
+        val courtDto: CourtDto = webTestClient.get()
+          .uri("/courts/id/SHEFCC")
+          .accept(MediaType.APPLICATION_JSON)
+          .headers(setAuthorisation(roles = listOf("HMPPS_REGISTERS_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectBodyResponse()
+
+        assertThat(courtDto.phoneNumbers).hasSize(2)
+        assertThat(courtDto.phoneNumbers[0].number).isEqualTo("0114 555 8989")
+      }
+    }
+  }
+}


### PR DESCRIPTION
First new model is Court - the other agency types will be similar to this (with an additional Agency catch-all type).

Court has one or more addresses - but typically just one. Courts have phone number but rarely email addresses.

So use existing Phone and Email tables with new join tables to link them to a court.

To prove the database schema is correct also needed to add the JPA classes.

To prove the JPA classes are correct also needed a test (CourtResourceIntTest) To create court  for test needed new DSL builders hence this PR is larger than I wanted.